### PR TITLE
Implement server switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+/config/secrets.yml
+
 # Ignore bundler config.
 /.bundle
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/LineLength:
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**'
+    - 'spec/interactors/*'
     - 'spec/controllers/api/v1/*'
     - 'db/schema.rb'
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Pour une installation manuelle, vous aurez besoin de :
 - un runtime java pour solr
 
  Pour vous simplifier la tâche, nous vous conseillons d'utiliser le script Ansible mis a disposition pour déployer votre
- architecture. Une tâche [Mina](https://github.com/mina-deploy/mina) est également disponible (fichier config/deploy.rb).
+ architecture. Une tâche [Mina](https://github.com/mina-deploy/mina) est également disponible (fichier config/deploy.rb). Vous pouvez la modifier pour entrer vos propres valeurs.
 
 Une fois cloné ce répertoire à l'aide de
 
@@ -291,11 +291,17 @@ Suppression database, en cas de problèmes :
 
 Il est conseillé de rajouter RAILS_ENV=production au début des commandes en environnement de production.
 
-### Mises à jour automatiques
+### Mises à jour automatique (Infrastructure à double server)
 
-La commande `bundle exec rake sirene_as_api:automatic_update_database` peut être lancée
-a chaque nouveau fichier.
-Le processus devrait être automatisé a l'installation du serveur.
+Pour assurer une continuité de service 24/7 et ce même pendant la reconstruction de la base de donnée, nous utilisons un système de double-server. Si vous désirez les réglages pour un seul server, reportez vous à la section suivante.
+
+Nous utilisons la commande `bundle exec rake sirene_as_api:dual_server_update` pour effectuer la mise à jour : le server va effectuer une mise à jour, tester si tout fonctionne, puis effectuer un switch d'IP fallback sur lui-même.
+
+Si vous avez 2 servers, vous pouvez modifier /config/switch_server.rb pour ajouter vos propres valeurs.
+
+### Mises à jour automatiques (1 seul server)
+
+La commande `bundle exec rake sirene_as_api:automatic_update_database` permet la mise à jour automatique de la base de donnée.
 Pour modifier la fréquence des mises à jour, modifiez config/schedule.rb
 puis exécutez la commande :
 
@@ -304,7 +310,7 @@ puis exécutez la commande :
 La gem [whenever](https://github.com/javan/whenever) s'occupe de mettre à jour
 vos tâches cron. Par défaut la mise à jour se fait à 4h30 du matin.
 
-L'API reste disponible sans interruptions pendant ce process, excepté ~ 3 heures lors de la
+L'API reste disponible sans interruptions pendant ce process, excepté ~ 3 à 4 heures lors de la
 suppression / réimportation du fichier stock au début de chaque mois.
 
 ## Sunspot / Solr

--- a/app/interactors/check_current_service.rb
+++ b/app/interactors/check_current_service.rb
@@ -1,0 +1,61 @@
+require 'json'
+
+class CheckCurrentService < SireneAsAPIInteractor
+  around do |interactor|
+    stdout_info_log 'Checking which server is currently running the API...'
+
+    interactor.call
+
+    stdout_success_log 'Other machine is currently in use. Update will start.'
+  end
+
+  def call
+    method = 'GET'
+    query = check_current_service_query
+    body = ''
+
+    response = OvhAPICall.new(method, query, body).call
+
+    other_machine_in_use?(response)
+  end
+
+  private
+
+  def check_current_service_query
+    "/ip/#{ip_fallback}/"
+  end
+
+  def ip_fallback
+    Rails.configuration.switch_server['ip_fallback']
+  end
+
+  def other_machine_in_use?(response)
+    current_service = get_current_service(response)
+
+    # It is safer to check if other machine is in use, not if our machine is in use.
+    if current_service == sibling_machine_name
+      context.success!
+    else
+      stdout_error_log "Other machine doesn't seem in use now. Can't start update"
+      context.fail!
+    end
+  end
+
+  def current_machine_name
+    File.open('/etc/hosts') do |file|
+      file.to_a.last.split(' ')[1]
+    end
+  end
+
+  def sibling_machine_name
+    machines = [Rails.configuration.switch_server['sirene_server1'],
+                Rails.configuration.switch_server['sirene_server2']]
+    machines.delete(current_machine_name)
+    machines[0]
+  end
+
+  def get_current_service(response)
+    service_description = JSON.parse(response.body)
+    service_description['routedTo']['serviceName']
+  end
+end

--- a/app/interactors/organizers/dual_server_update.rb
+++ b/app/interactors/organizers/dual_server_update.rb
@@ -1,0 +1,5 @@
+class DualServerUpdate
+  include Interactor::Organizer
+
+  organize AutomaticUpdateDatabase, TestSelfServer, SwitchServer
+end

--- a/app/interactors/organizers/dual_server_update.rb
+++ b/app/interactors/organizers/dual_server_update.rb
@@ -1,5 +1,5 @@
 class DualServerUpdate
   include Interactor::Organizer
 
-  organize AutomaticUpdateDatabase, TestSelfServer, SwitchServer
+  organize CheckCurrentService, AutomaticUpdateDatabase, TestSelfServer, SwitchServer
 end

--- a/app/interactors/organizers/select_and_apply_patches.rb
+++ b/app/interactors/organizers/select_and_apply_patches.rb
@@ -1,5 +1,5 @@
 class SelectAndApplyPatches
   include Interactor::Organizer
 
-  organize GetRelevantPatchesLinks, ApplyPatches, SolrReindex
+  organize GetRelevantPatchesLinks, ApplyPatches, SolrReindex, SolrBuildDictionary
 end

--- a/app/interactors/switch_server.rb
+++ b/app/interactors/switch_server.rb
@@ -1,12 +1,79 @@
+require 'digest'
+require 'net/http'
+
 class SwitchServer < SireneAsAPIInteractor
+  config.switch_server = config_for(:switch_server)
+
+  AK = Rails.application.secrets.OVH_APPLICATION_KEY
+  AS = Rails.application.secrets.OVH_APPLICATION_SECRET
+  CK = Rails.application.secrets.OVH_CONSUMER_KEY
+  # Timestamp as a constant since we need the same on request and signature
+  TSTAMP = Time.now.to_i.to_s
+
   around do |interactor|
+    stdout_info_log 'Starting server switch...'
     interactor.call
-
-
   end
 
   def call
+    method = 'POST'
+    adress = switch_server_request_adress
 
+    make_ovh_api_call(method, adress, body, timestamp)
   end
 
+  private
+
+  def make_ovh_api_call(method, adress, body)
+    uri = URI(adress)
+    req = Net::HTTP::Get.new(uri)
+    req['X-Ovh-Application'] = AK
+    req['X-Ovh-Timestamp'] = TSTAMP
+    req['X-Ovh-Signature'] = signature(method, query, body)
+    req['X-Ovh-Consumer'] = CK
+
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(req)
+    end
+  end
+
+  def switch_server_request_adress(ip_fallback)
+    "/ip/#{ip_fallback}/move"
+  end
+
+  def timestamp
+    Time.now.to_i.to_s
+  end
+
+  def signature(method, query, body)
+    '$1$' + Digest::SHA1.hexdigest(AS + '+' + CK + '+' + method + '+' + query + '+' + body + '+' + TSTAMP)
+  end
+
+  def ip_fallback
+    Rails.configuration.switch_server['ip_fallback']
+  end
+
+  def ovh_domain
+    'https://eu.api.ovh.com/1.0'
+  end
+
+  def destination_server
+    sirene_server1 = Rails.configuration.switch_server['sirene_server1']
+    sirene_server2 = Rails.configuration.switch_server['sirene_server2']
+
+    if current_machine_name == sirene_server1
+      sirene_server2
+    elsif current_machine_name == sirene_server2
+      sirene_server1
+    else
+      stdout_error_log 'Error during server switch: This server doesnt seem to be registered in Rails config.'
+      context.fail!
+    end
+  end
+
+  def current_machine_name
+    File.open('/etc/hosts') do |file|
+      file.to_a.last.split(' ')[1]
+    end
+  end
 end

--- a/app/interactors/switch_server.rb
+++ b/app/interactors/switch_server.rb
@@ -1,0 +1,12 @@
+class SwitchServer < SireneAsAPIInteractor
+  around do |interactor|
+    interactor.call
+
+
+  end
+
+  def call
+
+  end
+
+end

--- a/app/interactors/test_self_server.rb
+++ b/app/interactors/test_self_server.rb
@@ -1,0 +1,32 @@
+require 'json'
+
+# Best way to test if API works is to test full_text since it uses solr.
+# 'Montpellier' search have ~62K results. If we find over 60K, we can assume database is correctly filled.
+class TestSelfServer < SireneAsAPIInteractor
+
+  around do |interactor|
+    stdout_info_log 'Testing if current server API is up and running...'
+    interactor.call
+
+  end
+
+  def call
+    test_results = JSON.parse(execute_test)
+
+    return context.fail! unless test_results && test_results['total_results'] > 60_000
+    context.success!
+
+  rescue StandardError => error
+    stdout_error_log "Couldn't parse API result : #{error}"
+    context.fail!
+  end
+
+  private
+
+  def execute_test
+    `curl --resolve sirene.entreprise.api.gouv.fr:443:127.0.0.1 https://sirene.entreprise.api.gouv.fr/v1/full_text/montpellier`
+  rescue StandardError => error
+    stdout_error_log "Couldn't reach the API : #{error}"
+    context.fail!
+  end
+end

--- a/app/interactors/test_self_server.rb
+++ b/app/interactors/test_self_server.rb
@@ -3,11 +3,10 @@ require 'json'
 # Best way to test if API works is to test full_text since it uses solr.
 # 'Montpellier' search have ~62K results. If we find over 60K, we can assume database is correctly filled.
 class TestSelfServer < SireneAsAPIInteractor
-
   around do |interactor|
     stdout_info_log 'Testing if current server API is up and running...'
     interactor.call
-
+    stdout_success_log "This server's API is correctly working !"
   end
 
   def call

--- a/app/jobs/solr_build_dictionary.rb
+++ b/app/jobs/solr_build_dictionary.rb
@@ -1,0 +1,8 @@
+class SolrBuildDictionary < SireneAsAPIInteractor
+  around do
+    if context.rebuilding_database || !context.links.empty?
+      stdout_info_log 'Indexing finished ! Starting dictionary build...'
+      `RAILS_ENV=#{Rails.env} bundle exec rake sirene_as_api:build_dictionary`
+    end
+  end
+end

--- a/app/jobs/solr_reindex.rb
+++ b/app/jobs/solr_reindex.rb
@@ -2,9 +2,7 @@ class SolrReindex < SireneAsAPIInteractor
   around do
     if context.rebuilding_database || !context.links.empty?
       stdout_info_log 'Database was modified. Starting Solr reindexing...'
-      `rake sunspot:reindex`
-      stdout_info_log 'Indexing finished ! Starting dictionary build...'
-      `rake sirene_as_api:build_dictionary`
+      `RAILS_ENV=#{Rails.env} bundle exec rake sunspot:reindex`
     end
   end
 end

--- a/app/ovh/ovh_api_call.rb
+++ b/app/ovh/ovh_api_call.rb
@@ -1,0 +1,62 @@
+require 'digest'
+require 'net/http'
+require 'openssl'
+
+class OvhAPICall < SireneAsAPIInteractor
+  AK = Rails.application.secrets.OVH_APPLICATION_KEY
+  AS = Rails.application.secrets.OVH_APPLICATION_SECRET
+  CK = Rails.application.secrets.OVH_CONSUMER_KEY
+  # Timestamp as a constant since we need the same on request and signature
+  TSTAMP = Time.now.to_i.to_s
+
+  def initialize(method, query, body)
+    @method = method
+    @query = query
+    @body = body
+  end
+
+  # Currently only works for Get and Post, will update for more methods when needed
+  def call
+    uri = URI.parse(ovh_domain)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    # http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    request = build_request
+    add_headers(request)
+
+    http.request(request)
+  end
+
+  def build_request
+    return request_get if @method == 'GET'
+    return request_post if @method == 'POST'
+    raise 'Error : method parameter should be GET or POST'
+  end
+
+  def request_get
+    Net::HTTP::Get.new(@query)
+  end
+
+  def request_post
+    request = Net::HTTP::Post.new(@query)
+    request.add_field('Content-Type', 'application/json')
+    request.body = @body
+    request
+  end
+
+  def add_headers(request)
+    request['X-Ovh-Application'] = AK
+    request['X-Ovh-Timestamp'] = TSTAMP
+    request['X-Ovh-Signature'] = signature
+    request['X-Ovh-Consumer'] = CK
+  end
+
+  def signature
+    '$1$' + Digest::SHA1.hexdigest(AS + '+' + CK + '+' + @method + '+' + @query + '+' + @body + '+' + TSTAMP)
+  end
+
+  def ovh_domain
+    'https://eu.api.ovh.com/1.0'
+  end
+end

--- a/app/solr/solr_requests.rb
+++ b/app/solr/solr_requests.rb
@@ -16,7 +16,7 @@ class SolrRequests < SireneAsAPIInteractor
   end
 
   def build_dictionary
-    stdout_info_log 'Building suggester dictionary... This might take a while (~1-2 hours)'
+    stdout_info_log 'Building suggester dictionary... This might take a while (~3 hours)'
     begin
       request_build_dictionary
     rescue StandardError => error
@@ -45,10 +45,9 @@ class SolrRequests < SireneAsAPIInteractor
 
   def request_build_dictionary
     http_session = Net::HTTP.new('localhost', solr_port)
-    http_session.read_timeout = 7200 # 2 hours max to build dictionary
+    http_session.read_timeout = 14_400 # 4 hours max to build dictionary
     uri = "/solr/#{Rails.env}/suggesthandler?suggest.build=true"
     http_session.get(uri)
-    return
   end
 
   def solr_port

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,10 @@ module SireneAsAPI
 
     # Background tasks
     config.active_job.queue_adapter = :resque
+
+    # Custom config
+    config.switch_server = config_for(:switch_server)
+
     config.autoload_paths +=
       %W[#{config.root}/lib
          #{config.root}/app/interactors

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,28 +1,20 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
+###### SANDBOX ######
 
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
-
-# Learn more: http://github.com/javan/whenever
-
-every 1.day, at: '5:00 am' do
-  rake 'sirene_as_api:automatic_update_database', :environment => 'production'
-end
-
-every 1.day, at: '9:00 am' do
+every 1.day, at: '8:00 am' do
   rake 'sirene_as_api:automatic_update_database', :environment => 'sandbox'
 end
+
+###### PRODUCTION ######
+
+# CRON Job for single server update, uncomment if you have a single server
+
+# every 1.day, at: '4:30 am' do
+#   rake 'sirene_as_api:automatic_update_database', :environment => 'production'
+# end
+
+# CRON jobs for dual server update, comment out if you have a single server
+
+every 2.day, at: '4:30 am' do
+  rake 'sirene_as_api:dual_server_update', :environment => 'production'
+end
+

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,7 +1,7 @@
 ###### SANDBOX ######
 
 every 1.day, at: '8:00 am' do
-  rake 'sirene_as_api:automatic_update_database', :environment => 'sandbox'
+  rake 'sirene_as_api:automatic_update_database', environment: 'sandbox'
 end
 
 ###### PRODUCTION ######
@@ -13,8 +13,7 @@ end
 # end
 
 # CRON jobs for dual server update, comment out if you have a single server
-
-every 2.day, at: '4:30 am' do
-  rake 'sirene_as_api:dual_server_update', :environment => 'production'
+# The rake task is launched only if the server is not used, so each server will update every other day
+every 1.day, at: '4:30 am' do
+  rake 'sirene_as_api:dual_server_update', environment: 'production'
 end
-

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,3 +20,6 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  OVH_APPLICATION_KEY: dummy_value1
+  OVH_APPLICATION_SECRET: dummy_value2
+  OVH_CONSUMER_KEY: dummy_value3

--- a/config/switch_server.yml
+++ b/config/switch_server.yml
@@ -1,0 +1,4 @@
+production:
+  fallback_ip: '54.36.95.61'
+  sirene_server1: 'ns372885.ip-178-33-234.eu'
+  sirene_server2: 'ns3107905.ip-54-37-87.eu'

--- a/config/switch_server.yml
+++ b/config/switch_server.yml
@@ -1,4 +1,9 @@
 production:
-  fallback_ip: '54.36.95.61'
+  ip_fallback: '54.36.95.61'
   sirene_server1: 'ns372885.ip-178-33-234.eu'
   sirene_server2: 'ns3107905.ip-54-37-87.eu'
+
+test:
+  ip_fallback: '54.36.95.61'
+  sirene_server1: 'address1'
+  sirene_server2: 'address2'

--- a/spec/fixtures/vcr_cassettes/OvhAPIcall_check_current_service.yml
+++ b/spec/fixtures/vcr_cassettes/OvhAPIcall_check_current_service.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://eu.api.ovh.com/ip/54.36.95.61/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      X-Ovh-Timestamp:
+      - '1533289588'
+      X-Ovh-Signature:
+      - dummy-sign
+  response:
+    status:
+      code: 200
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 03 Aug 2018 09:46:28 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '213'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "organisationId": null,
+          "country": "fr",
+          "routedTo": {
+            "serviceName": "address1"
+          },
+          "ip": "dummy-ip/32",
+          "canBeTerminated": true,
+          "type": "failover",
+          "description": null
+        }
+    http_version:
+  recorded_at: Fri, 03 Aug 2018 09:46:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/interactors/check_current_service_spec.rb
+++ b/spec/interactors/check_current_service_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+require 'net/http'
+
+describe CheckCurrentService do
+  context 'When this machine is in service',
+          vcr: { cassette_name: 'OvhAPIcall_check_current_service', allow_playback_repeats: true } do
+    subject(:context) { described_class.call }
+    it 'fails the context' do
+      allow_any_instance_of(described_class).to receive(:current_machine_name).and_return('address1')
+      allow_any_instance_of(OvhAPICall).to receive(:signature).and_return('dummy-sign')
+
+      described_class.call
+      expect(context).to be_a_failure
+    end
+  end
+
+  context 'When this machine is not in service',
+          vcr: { cassette_name: 'OvhAPIcall_check_current_service', allow_playback_repeats: true } do
+    subject(:context) { described_class.call }
+    it 'succeed the context' do
+      allow_any_instance_of(described_class).to receive(:current_machine_name).and_return('address2')
+      allow_any_instance_of(OvhAPICall).to receive(:signature).and_return('dummy-sign')
+
+      described_class.call
+      expect(context).to be_a_success
+    end
+  end
+end

--- a/spec/interactors/test_server_spec.rb
+++ b/spec/interactors/test_server_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe TestSelfServer do
+  context 'when a success' do
+    subject(:context) { described_class.call}
+    it 'succeed the context' do
+      allow_any_instance_of(described_class).to receive(:execute_test).and_return(
+        "{\"total_results\":62703,\"total_pages\":6271,\"per_page\":10,\"page\":1,\"etablissement\":[{}]}")
+      expect(context).to be_a_success
+    end
+  end
+  context 'when database not full' do
+    subject(:context) { described_class.call}
+    it 'fails the context' do
+      allow_any_instance_of(described_class).to receive(:execute_test).and_return(
+        "{\"total_results\":30703,\"total_pages\":6271,\"per_page\":10,\"page\":1,\"etablissement\":[{}]}")
+      expect(context).to be_a_failure
+    end
+  end
+  context 'when test returns nil' do
+    subject(:context) { described_class.call}
+    it 'fails the context' do
+      allow_any_instance_of(described_class).to receive(:execute_test).and_return(nil)
+      expect(context).to be_a_failure
+    end
+  end
+end

--- a/spec/interactors/test_server_spec.rb
+++ b/spec/interactors/test_server_spec.rb
@@ -2,25 +2,34 @@ require 'rails_helper'
 
 describe TestSelfServer do
   context 'when a success' do
-    subject(:context) { described_class.call}
+    subject(:context) { described_class.call }
     it 'succeed the context' do
       allow_any_instance_of(described_class).to receive(:execute_test).and_return(
-        "{\"total_results\":62703,\"total_pages\":6271,\"per_page\":10,\"page\":1,\"etablissement\":[{}]}")
+        '{"total_results":62703,"total_pages":6271,"per_page":10,"page":1,"etablissement":[{}]}'
+      )
       expect(context).to be_a_success
     end
   end
   context 'when database not full' do
-    subject(:context) { described_class.call}
+    subject(:context) { described_class.call }
     it 'fails the context' do
       allow_any_instance_of(described_class).to receive(:execute_test).and_return(
-        "{\"total_results\":30703,\"total_pages\":6271,\"per_page\":10,\"page\":1,\"etablissement\":[{}]}")
+        '{"total_results":30703,"total_pages":6271,"per_page":10,"page":1,"etablissement":[{}]}'
+      )
       expect(context).to be_a_failure
     end
   end
   context 'when test returns nil' do
-    subject(:context) { described_class.call}
+    subject(:context) { described_class.call }
     it 'fails the context' do
       allow_any_instance_of(described_class).to receive(:execute_test).and_return(nil)
+      expect(context).to be_a_failure
+    end
+  end
+  context 'when test returns an error' do
+    subject(:context) { described_class.call }
+    it 'fails the context' do
+      allow_any_instance_of(described_class).to receive(:execute_test).and_raise('not working')
       expect(context).to be_a_failure
     end
   end


### PR DESCRIPTION
fix #84 
Added command `rake sirene_as_api:dual_server_update` that will :

1/ Check if fallback IP is on the other server
2/ If so, it updates itself
3/ Test itself to see if it works as intended
4/ Switch fallback IP to itself